### PR TITLE
Add support for charts with apiVersion v2

### DIFF
--- a/update/Dockerfile
+++ b/update/Dockerfile
@@ -1,5 +1,8 @@
 FROM lachlanevenson/k8s-helm:v2.16.1
 
 RUN apk add bash
-ADD entrypoint.sh /entrypoint.sh
+
+COPY --from=lachlanevenson/k8s-helm:v3.3.4 /usr/local/bin/helm /usr/local/bin/helm3
+COPY entrypoint.sh /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/update/entrypoint.sh
+++ b/update/entrypoint.sh
@@ -1,17 +1,24 @@
 #!/bin/bash -ex
 update_charts_dependencies() {
-  local PROJECT_DIR=$1
+  local HELM_INITIALIZED=false
+  local CHARTS_DIR=kubernetes/charts
 
-  CHARTS_DIR=kubernetes/charts
-
-  helm init --client-only
   for chart_path in ${CHARTS_DIR}/*; do
+    local HELM_BIN=helm
+
+    if [[ $(cat "${chart_path}/Chart.yaml" | grep -E "apiVersion: .?v2") ]]; then
+      HELM_BIN=helm3
+    elif [[ $HELM_INITIALIZED = false ]]; then
+      helm init --client-only
+      HELM_INITIALIZED=true
+    fi
+
     if [[ "${chart_path}/requirements.yaml" && ! -d "${chart_path}/charts" ]]; then
-      helm dependencies update ${chart_path}
+      ${HELM_BIN} dependencies update ${chart_path}
     else
       echo "No external dependencies found for ${chart_path}."
     fi
   done
 }
 
-update_charts_dependencies "${PROJECT_DIR}"
+update_charts_dependencies


### PR DESCRIPTION
The update action failed on charts with apiVersion v2

This adds the helm 3 binary to the image and uses that for charts with the new
API version.
