### PR TITLE
Update image version

### DIFF
--- a/update/action.yml
+++ b/update/action.yml
@@ -3,7 +3,7 @@ description: 'Update Helm dependencies'
 author: 'Soren Mathiasen'
 runs:
   using: 'docker'
-  image: 'docker://eu.gcr.io/tradeshift-public/helm-linter-update:1.0.0'
+  image: 'docker://eu.gcr.io/tradeshift-public/helm-linter-update:1.1.0'
 branding:
   icon: 'check-square'
   color: 'blue'


### PR DESCRIPTION
This updates the image with the new support for using helm 3 for
apiVersion v2 charts
