### PR TITLE
Add Kyverno validation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Docker build validate
         uses: tradeshift/actions-docker@v1
         with:
-          context: validate
+          context: quartermaster
           repository: eu.gcr.io/tradeshift-public/validate
           password: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_KEY_NOBASE64 }}
-        

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.DS_Store*
+

--- a/kubeval/entrypoint.sh
+++ b/kubeval/entrypoint.sh
@@ -6,6 +6,6 @@ CHARTS_DIR=kubernetes/charts
 
 for chart_path in ${CHARTS_DIR}/*; do
     echo "Processing ${chart_path}"
-    helm template ${chart_path} | kubeval --ignore-missing-schemas -v 1.18.1 --strict --exit-on-error
+    helm template ${chart_path} | kubeval --ignore-missing-schemas -v 1.21.14 --strict --exit-on-error
 done
 

--- a/kyverno/README.md
+++ b/kyverno/README.md
@@ -1,0 +1,33 @@
+This action runs Kyverno CLI against Helm charts to make sure they respect the policies. One of the validation
+rules in the `team` annotation. We need to know the names of the teams beforehand so that we can checkthe charts'
+annotations. We do that by listing the `Teams` resources in the cluster and fetching their `helmChartName` attribute.
+
+We also fetch all the policies (`kind: ClusterPolicy`) using `kubectl`, store them in a yaml file and use it in Kyvern
+CLI:
+```cgo
+$ kyverno apply cluster_policies.yaml --resource - -f teams.yaml
+```
+
+`--resource -` means that resources are passed to stdin (via `helm template` command). `-f` is the flag for a yaml file
+that contains the external data (like team names). And `cluster_policies.yaml` is all the policies we fetched from within
+the cluster via `kubectl`.
+
+More information: https://kyverno.io/docs/kyverno-cli/#apply
+
+# Caveats:
+
+In order to apply policies against charts, we need to render the charts. In order to render the charts, we need to find
+their override file (in `kubernetes/deployments` dir). That's because there has been no proper validation so far, therefore
+some values exist in `kubernetes/deployments` but not in `values.yaml` file. So rendering the chart without its override
+file can lead to errors.
+
+Finding the override file in `kubernetes/deployments` dir is not as easy as it should be, because:
+
+1. There can be multiple charts in a Github repo, and therefore multiple files in `kubernetes/deployments`
+2. Override files can have numbers at the beginning (e.g. `01_my-chart.config.yaml`). This is used to order chart deployment.
+
+That's why the action has an `if` statement that checks the following:
+
+1. If an override file exists with the same name as the chart, let's use that
+2. If an override file exists with the same name as the chart and any number followed by an underscore (`*_my-chart`), let's use that
+3. Anything else is not an override file.

--- a/kyverno/action.yaml
+++ b/kyverno/action.yaml
@@ -1,0 +1,46 @@
+name: Kyverno
+description: Apply policies against charts with Kyverno CLI
+runs:
+  using: "composite"
+  steps:
+    - name: Apply Kyverno policies
+      shell: bash
+      run: |
+        export CHARTS_DIR=kubernetes/charts
+        export OVERRIDES_DIR=kubernetes/deployments
+        export KUBE_API_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+        TEAMS=$(curl -k "https://kubernetes.default:443/apis/tradeshift.com/v1/teams" -H "Authorization: Bearer $KUBE_API_TOKEN" | kyverno jp "items[*].spec.helmChartName")
+        
+        # Fetch the policies from K8s cluster
+        for i in $(kubectl get clusterpolicies -o=name); do kubectl get $i -o yaml >> kyverno_policies.yaml && echo "---" >> kyverno_policies.yaml ;done
+        
+        # This context file will hold external data (e.g. team names) needed for validation rules.
+        cat <<EOT >> kyverno_context.yaml
+        policies:
+          - name: require-deployment-annotations
+            rules:
+              - name: team-annotation
+                values:
+                  teams: ${TEAMS}
+        EOT
+        
+        for CHART_PATH in ${CHARTS_DIR}/*; do
+          CHART_NAME=$(basename ${CHART_PATH})
+          for OVERRIDE_PATH in ${OVERRIDES_DIR}/*; do
+            # if a dir does not start with eks, it's either a manifest for legacy cluster or a bogus dir
+            if [[ $OVERRIDE_PATH == "kubernetes/deployments/eks"* ]]; then
+              if test -f ${OVERRIDE_PATH}/${CHART_NAME}.config.yaml; then
+                FILE_NAME="${OVERRIDE_PATH}/${CHART_NAME}.config.yaml"
+              elif test -f ${OVERRIDE_PATH}/*_${CHART_NAME}.config.yaml; then
+                FILE_NAME=$(find $OVERRIDE_PATH -maxdepth 1 -mindepth 1 -name "*_${CHART_NAME}.config.yaml")
+              else
+                echo "Error: Could not find override yaml file in ${OVERRIDE_PATH}."
+                exit 1
+              fi
+            else
+              echo "Unknown override file path: ${OVERRIDE_PATH}"
+            fi
+            # We specify git_hash, git_branch so that the rendered chart is as close to production environment as possible. Namespace, however, is specified at deploy time so we cannot figure it out at build time, therefore it's hardcoded. 
+            helm template ${CHART_PATH} -f ${FILE_NAME} --set git_hash=${{ github.event.pull_request.head.sha }} --set git_branch=${{ github.head_ref }} --set namespace=default | kyverno apply kyverno_policies.yaml --resource - -f kyverno_context.yaml
+          done
+        done

--- a/quartermaster/Dockerfile
+++ b/quartermaster/Dockerfile
@@ -1,0 +1,16 @@
+FROM eu.gcr.io/tradeshift-public/helm-check:0.26.0 as helm
+FROM eu.gcr.io/tradeshift-public/k8s-helm:v3.5.3
+
+RUN apk add bash curl
+
+COPY --from=helm /quartermaster /
+COPY --from=helm helm-check.sh /
+
+RUN curl -L "https://github.com/instrumenta/kubeval/releases/download/v0.16.1/kubeval-linux-amd64.tar.gz" -o /tmp/kubeval-linux-amd64.tar.gz
+RUN tar xvf /tmp/kubeval-linux-amd64.tar.gz -C /tmp
+RUN chmod +x /tmp/kubeval
+RUN mv /tmp/kubeval /usr/local/bin/
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/quartermaster/action.yml
+++ b/quartermaster/action.yml
@@ -1,0 +1,9 @@
+name: 'Kubernetes resource validator'
+description: 'Validates Kubernetes resourcs'
+author: 'Soren Mathiasen'
+runs:
+  using: 'docker'
+  image: 'docker://eu.gcr.io/tradeshift-public/validate:latest'
+branding:
+  icon: 'check-square'
+  color: 'blue'

--- a/quartermaster/entrypoint.sh
+++ b/quartermaster/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -ex
+export CHARTS_DIR=kubernetes/charts
+
+for chart_path in ${CHARTS_DIR}/*; do
+  if [[ ( -f "${chart_path}/requirements.yaml" && ! -d "${chart_path}/charts") || $(cat "${chart_path}/Chart.yaml" | grep -E "dependencies:")  ]]; then
+    helm dependencies update ${chart_path}
+  else
+    echo "No external dependencies found for ${chart_path}."
+  fi
+  helm template ${chart_path} | kubeval --ignore-missing-schemas -v 1.21.14 --strict --exit-on-error
+
+done
+/helm-check.sh kubernetes

--- a/validate/action.yml
+++ b/validate/action.yml
@@ -1,9 +1,10 @@
-name: 'Kubernetes resource validator'
-description: 'Validates Kubernetes resourcs'
-author: 'Soren Mathiasen'
+name: Kubernetes validate
+description: Action to validate chart configurations with policies
 runs:
-  using: 'docker'
-  image: 'docker://eu.gcr.io/tradeshift-public/validate:latest'
-branding:
-  icon: 'check-square'
-  color: 'blue'
+  using: "composite"
+  steps:
+    - name: Apply Kyverno
+      uses: tradeshift/actions-quartermaster/kyverno@master
+
+    - name: Run quartermaster
+      uses: tradeshift/actions-quartermaster/quartermaster@master


### PR DESCRIPTION
This is the second attempt at adding Kyverno CLI to the pipeline. The previous commit had to be reverted to unblock people. There were two issues:
1. `command kyverno not found`. In hindsight, this was an issue with the runner node and not the action code. I'll investigate if it comes up again.
2. Kubeveal takes an argument called `-v` that specifes the K8s version. We are running 1.21.14 everywhere but did not upgrade the version here, which resulted in Kubeveal falsly flagging chart as non-complient. This commit corrects the K8s version passed to Kubeveal.

BTW Kubeveal seems to be not maintained anymore, so it's a good thing that we can replace it with Kyverno CLI.

Original commit message:

This commit adds the following actions:

1. Kyverno: It's a composite action that runs a bash script inside which Kyverno CLI is used to apply policies against Helm charts. It's the POC for a successor to Quartermaster.
2. Quartermaster: A new directory is added called `quartermaster`, and the code from `validate` dir is moved to it.

This leaves us with the `validate` directory/action which is used by TS components to validate Helm charts. `validate` dir/action is now refactored to be a composite action to run
both Kyverno and Quartermaster, so that we can have a smooth transition period to Kyverno.

This change is not expected to introduce any issues or regressions into the pipeline. The only policy in Kyverno at the moment is validating team annotation on Deployments which is
already enforced by Quartermaster.