### PR TITLE
Add more verbose logging in case of error and fix bug

### DIFF
--- a/kyverno/action.yaml
+++ b/kyverno/action.yaml
@@ -34,8 +34,7 @@ runs:
               elif test -f ${OVERRIDE_PATH}/*_${CHART_NAME}.config.yaml; then
                 FILE_NAME=$(find $OVERRIDE_PATH -maxdepth 1 -mindepth 1 -name "*_${CHART_NAME}.config.yaml")
               else
-                echo "Error: Could not find override yaml file in ${OVERRIDE_PATH}."
-                exit 1
+                echo "Could not find override yaml file in ${OVERRIDE_PATH} for ${CHART_NAME} chart (${CHART_PATH})."
               fi
             else
               echo "Unknown override file path: ${OVERRIDE_PATH}"


### PR DESCRIPTION
Add a more verbose message when an override file cannot be found for easier debugging.

Also, it is a valid scenario where there are charts but no override files for them, so
if we do not find an override file for a chart, we should not `exit 1`. Instead just
pring a message and move on.