### PR TITLE
fix: specifying runner type

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Example:
 ```
 jobs:
   run:
-    runs-on: self-hosted
+    runs-on: [self-hosted,ts-large-x64-docker-large]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
This pull request specifies a runner type for workflows on your repo that are missing it. Having only `runs-on: self-hosted`could cause unexpected behavior, making your workflow run on a runner that you didn't intend.

Soon this change will be mandatory, and any workflows with only `runs-on: self-hosted` will not work anymore.  
	
You can read more about the available runner types [here](https://github.com/Tradeshift/actions-runner-autoscaler#available-runners).